### PR TITLE
WIP: Migrate from jnv.unattended-upgrades to hifis.unattended_upgrades

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -26,9 +26,9 @@
 - src: https://github.com/jkirk/ansible-role-website.git
   version: 94d69ea
   name: jkirk.website
-- src: https://github.com/jnv/ansible-role-unattended-upgrades.git
-  version: f9e09a3
-  name: jnv.unattended-upgrades
+- src: https://github.com/hifis-net/ansible-role-unattended-upgrades.git
+  version: 0f44252
+  name: hifis.unattended_upgrades
 - src: https://github.com/Oefenweb/ansible-hostname
   version: fd9e966
   name: Oefenweb.hostname


### PR DESCRIPTION
jnv.unattended-upgrades has been deprecated, see: jnv/ansible-role-unattended-upgrades#98

The author (@jnv) states:

> Unfortunately I don't have time nor motivation to maintain this role
> anymore, so with this I announce that the jnv.unattended-upgrades role
> is deprecated.

@hifis-net (Thx!) took over and maintains a fork of the ansible role which is now called `hifis.unattended_upgrades`.

---

WIP: Currently the fork is [56 commits ahead](https://github.com/jnv/ansible-role-unattended-upgrades/compare/master...hifis-net:ansible-role-unattended-upgrades:0f44252)

The commits till 0f44252 have been reviewed and look good so far. We have to test a migration and if everything works out fine, merge this to master.